### PR TITLE
Bug #43 duplicate items

### DIFF
--- a/link/linkController.js
+++ b/link/linkController.js
@@ -44,7 +44,7 @@ module.exports.exchange = async (req, res) => {
     const item = await plaid.getItem(accessToken);
     item.accessToken = accessToken;
     // If item with same institution already exists, replace it
-    mongoDBConnection.get().collection('LanternUsers').find({'auth.email': req.user.email}).toArray((e, docs) => {
+    mongoDBConnection.get().collection('LanternUsers').find({ 'auth.email': req.user.email }).toArray((e, docs) => {
       let replaceItem = false;
       if (docs[0].items && docs[0].items.length > 0) {
         for (let i = 0; i < docs[0].items.length; i++) {
@@ -52,11 +52,11 @@ module.exports.exchange = async (req, res) => {
             replaceItem = true;
             // Replace item in user's item array
             docs[0].items[i] = item;
-            mongoDBConnection.get().collection('LanternUsers').updateOne({'auth.email': req.user.email}, {$set: {items: docs[0].items}}, (e, dbRes) => {
+            mongoDBConnection.get().collection('LanternUsers').updateOne({ 'auth.email': req.user.email }, { $set: { items: docs[0].items } }, (e, dbRes) => {
               if (e) {
-                res.status(500).json({message: 'Database insert Item Error!'});
+                res.status(500).json({ message: 'Database insert Item Error!' });
               } else {
-                res.status(200).json({token: accessToken});
+                res.status(200).json({ token: accessToken });
               }
             });
           }
@@ -64,16 +64,15 @@ module.exports.exchange = async (req, res) => {
       }
       // No matching item found - push item to database
       if (!replaceItem) {
-        mongoDBConnection.get().collection('LanternUsers').updateOne({'auth.email': req.user.email}, {$push: {items: item}}, (e, dbRes) => {
+        mongoDBConnection.get().collection('LanternUsers').updateOne({ 'auth.email': req.user.email }, { $push: { items: item } }, (e, dbRes) => {
           if (e) {
-            res.status(500).json({message: 'Database insert Item Error!'});
+            res.status(500).json({ message: 'Database insert Item Error!' });
           } else {
-            res.status(200).json({token: accessToken});
+            res.status(200).json({ token: accessToken });
           }
         });
       }
     });
-
   } catch (error) {
     // handle error
     console.log(error);

--- a/link/linkController.js
+++ b/link/linkController.js
@@ -43,13 +43,33 @@ module.exports.exchange = async (req, res) => {
     // Store full item and accessTokens in database
     const item = await plaid.getItem(accessToken);
     item.accessToken = accessToken;
-    mongoDBConnection.get().collection('LanternUsers').updateOne({ 'auth.email': req.user.email }, { $push: { items: item } }, (e, dbRes) => {
-      if (e) {
-        res.status(500).json({ message: 'Database insert Item Error!' });
-      } else {
-        res.status(200).json({ token: accessToken });
+    // If item with same institution already exists, replace it
+    mongoDBConnection.get().collection('LanternUsers').find({'auth.email': req.user.email}).toArray((e, docs) => {
+      if (docs[0].items && docs[0].items.length > 0) {
+        for (let i = 0; i < docs[0].items.length; i++) {
+          if (docs[0].items[i].institution_id === item.institution_id) {
+            // Replace item in user's item array
+            docs[0].items[i] = item;
+            mongoDBConnection.get().collection('LanternUsers').updateOne({'auth.email': req.user.email}, { $set: {items: docs[0].items} }, (e, dbRes) => {
+              if (e) {
+                res.status(500).json({ message: 'Database insert Item Error!' });
+              } else {
+                res.status(200).json({ token: accessToken });
+              }
+            });
+          }
+        }
       }
+      // No matching item found - push item to database
+      mongoDBConnection.get().collection('LanternUsers').updateOne({ 'auth.email': req.user.email }, { $push: { items: item } }, (e, dbRes) => {
+        if (e) {
+          res.status(500).json({ message: 'Database insert Item Error!' });
+        } else {
+          res.status(200).json({ token: accessToken });
+        }
+      });
     });
+
   } catch (error) {
     // handle error
     console.log(error);

--- a/link/linkController.js
+++ b/link/linkController.js
@@ -45,29 +45,33 @@ module.exports.exchange = async (req, res) => {
     item.accessToken = accessToken;
     // If item with same institution already exists, replace it
     mongoDBConnection.get().collection('LanternUsers').find({'auth.email': req.user.email}).toArray((e, docs) => {
+      let replaceItem = false;
       if (docs[0].items && docs[0].items.length > 0) {
         for (let i = 0; i < docs[0].items.length; i++) {
           if (docs[0].items[i].institution_id === item.institution_id) {
+            replaceItem = true;
             // Replace item in user's item array
             docs[0].items[i] = item;
-            mongoDBConnection.get().collection('LanternUsers').updateOne({'auth.email': req.user.email}, { $set: {items: docs[0].items} }, (e, dbRes) => {
+            mongoDBConnection.get().collection('LanternUsers').updateOne({'auth.email': req.user.email}, {$set: {items: docs[0].items}}, (e, dbRes) => {
               if (e) {
-                res.status(500).json({ message: 'Database insert Item Error!' });
+                res.status(500).json({message: 'Database insert Item Error!'});
               } else {
-                res.status(200).json({ token: accessToken });
+                res.status(200).json({token: accessToken});
               }
             });
           }
         }
       }
       // No matching item found - push item to database
-      mongoDBConnection.get().collection('LanternUsers').updateOne({ 'auth.email': req.user.email }, { $push: { items: item } }, (e, dbRes) => {
-        if (e) {
-          res.status(500).json({ message: 'Database insert Item Error!' });
-        } else {
-          res.status(200).json({ token: accessToken });
-        }
-      });
+      if (!replaceItem) {
+        mongoDBConnection.get().collection('LanternUsers').updateOne({'auth.email': req.user.email}, {$push: {items: item}}, (e, dbRes) => {
+          if (e) {
+            res.status(500).json({message: 'Database insert Item Error!'});
+          } else {
+            res.status(200).json({token: accessToken});
+          }
+        });
+      }
     });
 
   } catch (error) {


### PR DESCRIPTION
The purpose of this change is to fix a bug found when creating the frontend cashflow component.  Repeated logging in using the plaid link endpoints resulted in numerous nearly identical items being added to a user's account, representing login credentials for the same institution.  This change makes it so that in the case that someone logs into the same financial institution multiple times, only the latest created Item will be saved on the user's profile.  So there will only be one plaid item (login credentials) allowed for each financial institution.

Resolves #43 